### PR TITLE
Fix turborepo build configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,5 +24,6 @@
     "url": "https://github.com/CarlosMundim/CC-01.git"
   },
   "author": "Carlos Mundim",
-  "license": "MIT"
+  "license": "MIT",
+  "packageManager": "bun@1.2.14"
 }


### PR DESCRIPTION
## Summary
- specify `packageManager` so Turbo can find Bun

## Testing
- `bun run build` *(fails: Failed to fetch `Inter` from Google Fonts)*
- `bun run lint` *(fails: Next.js ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_683fbfce9ef083268c9ed8e6ff999f02